### PR TITLE
Treasure Hunt - JuanPablo

### DIFF
--- a/pablodeployment.yaml
+++ b/pablodeployment.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: treasure-pablo
+  namespace: treasure-hunt
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: treasure-pablo
+  template:
+    metadata:
+      labels:
+        app: treasure-pablo
+    spec:
+      containers:
+        - name: web
+          image: juanpabloante/treasure-2140132:latest
+          ports:
+            - containerPort: 80
+          env:
+            - name: TITLE
+              value: "Treasure Hunt — Pablo"
+            - name: STUDENT
+              value: "Juan Pablo Ante"
+            - name: SALT
+              value: "DS3univalle"
+            - name: KEY_HASH
+              value: "45253620d69020d325ab17632cd709f007152a3d621dd09c50449df386f6efd9"
+            - name: CLUE
+              valueFrom:
+                secretKeyRef:
+                  name: pablo-clue
+                  key: CLUE
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: treasure-pablo
+  namespace: treasure-hunt
+spec:
+  selector:
+    app: treasure-pablo
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80
+      # nodePort: 31080   # (opcional) fija uno en el rango 30000–32767
+  type: NodePort
+

--- a/pablosecret.yaml
+++ b/pablosecret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+ name: pablo-clue
+ namespace: treasure-hunt
+type: Opaque
+data:
+ CLUE: Q0xVRS1KUVVFOiJTVEVQIg==


### PR DESCRIPTION
This pull request introduces Kubernetes configuration files to deploy and expose the `treasure-pablo` application in the `treasure-hunt` namespace. The main changes are the addition of a deployment and service for the application, as well as a secret for securely providing a clue to the container.

**Kubernetes deployment and service setup:**

* Added `pablodeployment.yaml` to define a `Deployment` for the `treasure-pablo` app, specifying container image, environment variables, and labels for pod selection.
* Added a `Service` in `pablodeployment.yaml` to expose the `treasure-pablo` deployment using a `NodePort`, making it accessible within the cluster and optionally from outside.

**Secret management:**

* Added `pablosecret.yaml` to create an Opaque Kubernetes `Secret` named `pablo-clue` in the `treasure-hunt` namespace, storing the base64-encoded clue value.
* Configured the deployment to inject the secret value for the `CLUE` environment variable into the container using `env.valueFrom.secretKeyRef`.